### PR TITLE
Move USB_MIDI guard to TouchBass.cpp call site

### DIFF
--- a/TouchBass.cpp
+++ b/TouchBass.cpp
@@ -24,7 +24,9 @@ int main(void) {
 	hw.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_48KHZ);
 
 	HW::hw().setHW(&hw);
+#ifndef USB_MIDI
 	HW::hw().startLog();
+#endif
 
 	touch.Init(hw);
 	bass.Init(hw.AudioSampleRate(), hw.AudioBlockSize());


### PR DESCRIPTION
## Problem

The previous fix for Windows USB MIDI enumeration placed a `#ifndef USB_MIDI` guard inside `log.h`'s `startLog()` method. As noted by @bleeptools, `log.h` is a generic utility shared across instruments and should not contain instrument-specific flags like `USB_MIDI`.

## Fix

Move the guard to the call site in `TouchBass.cpp`, wrapping `HW::hw().startLog()` directly:

```cpp
#ifndef USB_MIDI
    HW::hw().startLog();
#endif
```

This keeps `log.h` clean and generic while preserving the fix: on Windows, initializing the serial log when `USB_MIDI` is active causes CDC/USB MIDI enumeration conflicts.

The companion commit on `main` restores `log.h` to its original unconditional form.

## Test plan

- [x] Build with `USB_MIDI` defined — `startLog()` should be skipped, USB MIDI should enumerate correctly on Windows
- [x] Build without `USB_MIDI` — `startLog()` should run as normal
- [x] Verify on non-Windows OS (macOS / Linux) that behaviour is unchanged